### PR TITLE
include docs folder in the sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,4 +41,4 @@ Source = "https://github.com/attakei-lab/sphinxcontrib-sass"
 name = "sphinxcontrib.sass"
 
 [tool.flit.sdist]
-exclude = [".github", "docs"]
+exclude = [".github"]


### PR DESCRIPTION
Useful for Debian and other packagers, we can build them as a test